### PR TITLE
Make all inputs expect papers and conference_details optional

### DIFF
--- a/aclpub2/generate.py
+++ b/aclpub2/generate.py
@@ -405,15 +405,15 @@ def load_configs(root: Path):
     """
     Loads all conference configuration files defined in the root directory.
     """
-    conference = load_config("conference_details", root)
-    papers = load_config("papers", root)
+    conference = load_config("conference_details", root, required=True)
+    papers = load_config("papers", root, required=True)
     for paper in papers:
         paper["title"] = normalize_latex_string(paper["title"])
     sponsors = load_config("sponsors", root)
     prefaces = load_config("prefaces", root)
     organizing_committee = load_config("organizing_committee", root)
     program_committee = load_config("program_committee", root)
-    invited_talks = load_config("invited_talks", root, required=False)
+    invited_talks = load_config("invited_talks", root)
 
     return (
         conference,
@@ -473,7 +473,7 @@ def load_configs_handbook(root: Path):
     )
 
 
-def load_config(config: str, root: Path, required=True):
+def load_config(config: str, root: Path, required=False):
     path = Path(root, f"{config}.yml")
     if not path.exists():
         if required:

--- a/aclpub2/templates/proceedings.tex
+++ b/aclpub2/templates/proceedings.tex
@@ -64,6 +64,7 @@
 %%%%%%%%%%%%
 % Sponsors %
 %%%%%%%%%%%%
+\BLOCK{if sponsors}
 \setcounter{page}{2}
 \vspace*{2cm}
 \noindent
@@ -88,6 +89,7 @@
   \bigskip
 \BLOCK{endfor}
 \newpage
+\BLOCK{endif}
 
 
 %%%%%%%%%%%%%
@@ -123,6 +125,7 @@ ISBN \VAR{conference.isbn}
 %%%%%%%%%%%%
 % Prefaces %
 %%%%%%%%%%%%
+\BLOCK{if prefaces}
 \BLOCK{for preface in prefaces}
   \begin{center}
    { \Large \textbf{\VAR{preface.title}}}
@@ -131,10 +134,12 @@ ISBN \VAR{conference.isbn}
   \VAR{load_file(root, "prefaces", preface.file)}
   \newpage
 \BLOCK{endfor}
+\BLOCK{endif}
 
 %%%%%%%%%%%%%%%%%%%%%%%%
 % Organizing Committee %
 %%%%%%%%%%%%%%%%%%%%%%%%
+\BLOCK{if organizing_committee}
 \begin{center}
 {\Large \textbf{Organizing Committee}}
 \end{center}
@@ -147,10 +152,12 @@ ISBN \VAR{conference.isbn}
   \newline
 \BLOCK{endfor}
 \newpage
+\BLOCK{endif}
 
 %%%%%%%%%%%%%%%%%%%%%
 % Program Committee %
 %%%%%%%%%%%%%%%%%%%%%
+\BLOCK{if program_committee}
 \begin{center}
 \Large \textbf{Program Committee}
 \end{center}
@@ -184,6 +191,7 @@ ISBN \VAR{conference.isbn}
 
 \BLOCK{endfor}
 \newpage
+\BLOCK{endif}
 
 %%%%%%%%%%%%%%%%%
 % Invited Talks %


### PR DESCRIPTION
In the extreme case, only papers and the details of the conference/workshop are technically necessary.
This allows the maximally flexible usage of our generation script.