### PR TITLE
Run pax only once

### DIFF
--- a/aclpub2/templates/proceedings.tex
+++ b/aclpub2/templates/proceedings.tex
@@ -5,7 +5,6 @@
 \usepackage{hyperref}
 \usepackage[utf8]{inputenc}
 \usepackage{multicol}
-\usepackage{pax}
 \usepackage{pdfpages}
 \usepackage{times}
 


### PR DESCRIPTION
If the .pax files already exist, no need to re-generated them.