### PR TITLE
Output to folder structure consumed by ACL Anthology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+/output
 */__pycache__/
 *.log
 *.aux

--- a/aclpub2/generate.py
+++ b/aclpub2/generate.py
@@ -13,7 +13,7 @@ import shutil
 PARENT_DIR = Path(__file__).parent
 
 
-def generate_proceedings(path: str, overwrite: bool):
+def generate_proceedings(path: str, overwrite: bool, outdir: str):
     root = Path(path)
     build_dir = Path("build")
     build_dir.mkdir(exist_ok=True)
@@ -94,13 +94,13 @@ def generate_proceedings(path: str, overwrite: bool):
         ]
     )
 
-    output_dir = Path("output")
+    output_dir = Path(outdir)
     shutil.rmtree(str(output_dir), ignore_errors=True)
     output_dir.mkdir()
-    rearrange_outputs(build_dir, output_dir)
+    rearrange_outputs(root, build_dir, output_dir)
 
 
-def rearrange_outputs(build_dir: Path, output_dir: Path):
+def rearrange_outputs(input_path: Path, build_dir: Path, output_dir: Path):
     # Copy proceedings
     shutil.copy2(
         Path(build_dir, "proceedings.pdf"), Path(output_dir, "proceedings.pdf")
@@ -111,7 +111,9 @@ def rearrange_outputs(build_dir: Path, output_dir: Path):
     for file in Path(build_dir, "watermarked_pdfs").glob("*.pdf"):
         shutil.copy2(file, output_watermarked)
     # Copy the front matter as 0.pdf.
-    shutil.copy2(Path(build_dir, "front_matter.pdf"), Path(output_dir, "0.pdf"))
+    shutil.copy2(Path(build_dir, "front_matter.pdf"), Path(output_watermarked, "0.pdf"))
+    # Copy the inputs.
+    shutil.copytree(input_path, Path(output_dir, "inputs"))
 
 
 def find_page_offset(proceedings_pdf):

--- a/aclpub2/generate.py
+++ b/aclpub2/generate.py
@@ -94,6 +94,25 @@ def generate_proceedings(path: str, overwrite: bool):
         ]
     )
 
+    output_dir = Path("output")
+    shutil.rmtree(str(output_dir), ignore_errors=True)
+    output_dir.mkdir()
+    rearrange_outputs(build_dir, output_dir)
+
+
+def rearrange_outputs(build_dir: Path, output_dir: Path):
+    # Copy proceedings
+    shutil.copy2(
+        Path(build_dir, "proceedings.pdf"), Path(output_dir, "proceedings.pdf")
+    )
+    # Copy watermarked PDFs.
+    output_watermarked = Path(output_dir, "watermarked_pdfs")
+    output_watermarked.mkdir()
+    for file in Path(build_dir, "watermarked_pdfs").glob("*.pdf"):
+        shutil.copy2(file, output_watermarked)
+    # Copy the front matter as 0.pdf.
+    shutil.copy2(Path(build_dir, "front_matter.pdf"), Path(output_dir, "0.pdf"))
+
 
 def find_page_offset(proceedings_pdf):
     offset = None

--- a/bin/generate
+++ b/bin/generate
@@ -18,9 +18,15 @@ if __name__ == "__main__":
         action="store_true",
         help="If set, overwrites the generated files in the output.",
     )
+    parser.add_argument(
+        "--outdir",
+        type=str,
+        default="output",
+        help="Directory to write final, ACL Anthology compatible generation outputs to.",
+    )
 
     args = parser.parse_args()
     if args.proceedings == True:
-        generate_proceedings(args.path, args.overwrite)
+        generate_proceedings(args.path, args.overwrite, args.outdir)
     if args.handbook == True:
         generate_handbook(args.path, args.overwrite)


### PR DESCRIPTION
Output folder structure is as follow.
```
output/
|----proceedings.pdf
|----0.pdf  # Front matter.
|----watermarked_pdfs
|----|----1.pdf
|----|----12pdf
...
```
@crux82 please comment on whether this works for ACL Anthology