### PR TITLE
Formatting changes.

### DIFF
--- a/aclpub2/templates/handbook.tex
+++ b/aclpub2/templates/handbook.tex
@@ -70,6 +70,8 @@
 % for each part of the conference, add the .bib file produced with
 % meta2bibtex.py here:
 
+% Set indents to zero everywhere.
+\setlength{\parindent}{0pt}
 
 %TO BE UNCOMMENTED
 %\bibliography{auto/tacl/papers.bib}

--- a/aclpub2/templates/handbook.tex
+++ b/aclpub2/templates/handbook.tex
@@ -182,12 +182,12 @@
         \VAR{join_names(", ", area.members)}\\
       \BLOCK{endif}
     \BLOCK{endfor}
-  \BLOCK{elif block.type is equalto("name_block")}
+  \BLOCK{elif block.type is equalto("split_name_block")}
     \BLOCK{for name_block in group_by_last_name(block.entries)}
       \VAR{join_names(", ", name_block)}\\
       \newline
     \BLOCK{endfor}
-  \BLOCK{elif block.type is equalto("name_block_without_newlines")}
+  \BLOCK{elif block.type is equalto("name_block")}
     \VAR{to_string_sorting_by_last_name(block.entries)}\\
     \newline
   \BLOCK{else}


### PR DESCRIPTION
name_block now displays all the reviewer names together, rather than splitting into alphabetical blocks.