### PR TITLE
Remove seemingly spurious counter

### DIFF
--- a/aclpub2/templates/handbook.tex
+++ b/aclpub2/templates/handbook.tex
@@ -14,6 +14,8 @@
 \usepackage{tabu}
 \usepackage{wrapfig}
 \usepackage{tikz}
+\usepackage{CJKutf8}
+\newcommand{\chinese}[1]{\begin{CJK}{UTF8}{bsmi}#1\end{CJK}}
 \newunicodechar{ș}{\cb{s}}
 \newunicodechar{ț}{\cb{t}}
 

--- a/aclpub2/templates/handbook.tex
+++ b/aclpub2/templates/handbook.tex
@@ -317,7 +317,6 @@
   \setheaders{Main Conference Program (Detailed Program)}{Main Conference Program (Detailed Program)}
 
   \BLOCK{for session in sessions}
-    \BLOCK{set count = namespace(value=1)}
     \BLOCK{if session.subsessions|length > 0}
      \leavevmode\newline{\Large{\textbf{\VAR{session.title} - \VAR{session.start_time.strftime('%H:%M')}-\VAR{session.end_time.strftime('%H:%M')}}}}
       \BLOCK{for subsession in session.subsessions}
@@ -337,9 +336,6 @@
               \BLOCK{if "TACL" in paper.attributes.Source}\footnotesize{[TACL]}\BLOCK{endif}
               \BLOCK{if "CL" == paper.attributes.Source}\footnotesize{[CL]}\BLOCK{endif}
               \BLOCK{if "DEMO" == paper.attributes.Source}\footnotesize{[DEMO]}\BLOCK{endif}
-            \BLOCK{endif}
-            \BLOCK{if 'Poster' in subsession.title and "DEMO" != paper.attributes.Source}
-            \footnotesize{\textbf{ \#\VAR{count.value} } }  \BLOCK{set count.value = count.value + 1}
             \BLOCK{endif}
             \textbf{\footnotesize{\VAR{paper.title}}}\newline
             \BLOCK{if paper.authors}


### PR DESCRIPTION
- Seemingly spurious counter was preventing handbook with poster sessions from compiling.
- Adds handling of Chinese characters, with the `\chinese` macro.