### PR TITLE
Fixing lower-case issue from Softconf script

### DIFF
--- a/softconf/softconf2aclpub.py
+++ b/softconf/softconf2aclpub.py
@@ -38,12 +38,14 @@ def capitalize_name(name):
         elif count > 1:
             names = tokens[0].split('-')
             toks = []
-            for i, name in enumerate(names):
+            for i, n in enumerate(names):
                 if i != 1:
-                    toks += [name[0].upper()+name[1:].lower()]
+                    toks += [n[0].upper()+n[1:].lower()]
                 else:
-                    if name == name.lower():
-                        toks += [name]
+                    if n == n.lower():
+                        toks += [n]
+                    elif n[0] == n[0].upper():
+                        toks += [n[0].upper()+n[1:].lower()]
         tokens_capitalized = "-".join(toks)
     else:
         tokens_capitalized = [token[0].upper()+token[1:].lower() for token in tokens]

--- a/softconf/softconf2aclpub.py
+++ b/softconf/softconf2aclpub.py
@@ -31,7 +31,22 @@ def capitalize_name(name):
         :return: the string where the first letter of every token is capitalized
     """
     tokens = name.split(" ")
-    tokens_capitalized = [token[0].upper()+token[1:].lower() for token in tokens]
+    if '-' in tokens[0]:
+        count = tokens[0].count('-')
+        if count == 1:
+            toks = [tok[0].upper()+tok[1:].lower() for tok in tokens[0].split('-')]
+        elif count > 1:
+            names = tokens[0].split('-')
+            toks = []
+            for i, name in enumerate(names):
+                if i != 1:
+                    toks += [name[0].upper()+name[1:].lower()]
+                else:
+                    if name == name.lower():
+                        toks += [name]
+        tokens_capitalized = "-".join(toks)
+    else:
+        tokens_capitalized = [token[0].upper()+token[1:].lower() for token in tokens]
     return " ".join(tokens_capitalized)
 
 def full_name(first_name, last_name, middle_name=None):
@@ -259,10 +274,11 @@ def get_papers():
                             "username": row[f"{i}: Username"],
                             "institution": tex_escape(row[f"{i}: Affiliation"])
                         })
+                sub_type = "Submission Type" if "Submission Type" in row else "Paper type"
                 paper = {
                     "abstract": tex_escape(row["Abstract"]),
                     "attributes": {
-                        "paper_type": row["Submission Type"],
+                        "paper_type": row[sub_type],
                         "presentation_type": "N/A",
                         "submitted_area": row["Track"] if "Track" in row else "",
                     },

--- a/softconf/softconf2aclpub.py
+++ b/softconf/softconf2aclpub.py
@@ -42,9 +42,9 @@ def capitalize_name(name):
                 if i != 1:
                     toks += [n[0].upper()+n[1:].lower()]
                 else:
-                    if n == n.lower():
+                    if n[0] == n[0].lower():
                         toks += [n]
-                    elif n[0] == n[0].upper():
+                    else:
                         toks += [n[0].upper()+n[1:].lower()]
         tokens_capitalized = "-".join(toks)
     else:


### PR DESCRIPTION
Addresses issue where names joined by "-" were lowercased in the softconf script.
The proposed approach follows this pattern:

- Name1-Name2 -> Name1-Name2
- Name1-name2-Name3 -> Name1-name2-Name3
- Name1-Name2-Name3 -> Name1-Name2-Name3

The first name segment is always capitalised as is the last name segment. Only the middle segment is left lower-cased if it initially appears lowercased.