### PR TITLE
Add Compatability with API2

### DIFF
--- a/openreview/or2papers.py
+++ b/openreview/or2papers.py
@@ -153,7 +153,10 @@ def main(username, password, venue, download_all, download_pdfs):
                     ) as op:
                         op.write(f)
         if download_pdfs:
-            f = client_acl.get_pdf(id=paper["openreview_id"])
+            try:
+                f = client_acl.get_pdf(id=paper["openreview_id"])
+            except:
+                f = client_acl_v2.get_pdf(id=paper["openreview_id"])
             with open(
                 os.path.join(papers_folder, str(paper["id"]) + ".pdf"), "wb"
             ) as op:

--- a/openreview/or2papers.py
+++ b/openreview/or2papers.py
@@ -30,7 +30,7 @@ def main(username, password, venue, download_all, download_pdfs):
 
     try:
         venue_group = client_acl_v2.get_group(venue)
-        is_v2 = venue_group.domain is not None and venue_group.domain == venue_group.id
+        in_v2 = venue_group.domain is not None and venue_group.domain == venue_group.id
     except:
         print(f"{venue} not found")
         exit()
@@ -47,11 +47,15 @@ def main(username, password, venue, download_all, download_pdfs):
     if not os.path.exists(attachments_folder):
         os.mkdir(attachments_folder)
 
-    submissions = list(
-        openreview.tools.iterget_notes(
-            client_acl, invitation=venue + "/-/Blind_Submission", details="original"
+    if not in_v2:
+        submissions = list(
+            openreview.tools.iterget_notes(
+                client_acl, invitation=venue + "/-/Blind_Submission", details="original"
+            )
         )
-    )
+    else:
+        submissions = client_acl_v2.get_all_notes(invitation=venue + "/-/Submission")
+
     decision_by_forum = {
         d.forum: d
         for d in list(

--- a/openreview/or2papers.py
+++ b/openreview/or2papers.py
@@ -21,8 +21,18 @@ def main(username, password, venue, download_all, download_pdfs):
         client_acl = openreview.Client(
             baseurl="https://api.openreview.net", username=username, password=password
         )
+        client_acl_v2 = openreview.Client(
+            baseurl="https://api2.openreview.net", username=username, password=password
+        )
     except:
         print("OpenReview connection refused")
+        exit()
+
+    try:
+        venue_group = client_acl_v2.get_group(venue)
+        is_v2 = venue_group.domain is not None and venue_group.domain == venue_group.id
+    except:
+        print(f"{venue} not found")
         exit()
 
     if not download_all or not download_pdfs:

--- a/openreview/or2papers.py
+++ b/openreview/or2papers.py
@@ -112,7 +112,7 @@ def main(username, password, venue, download_all, download_pdfs):
             else "",
             "file": str(submission.number) + ".pdf",  # str(len(papers)+1) + ".pdf",
             "pdf_file": get_content_from(submission, "pdf").split("/")[-1],
-            "decision": get_content_from(decision_by_forum[submission.id], "decision"),
+            "decision": get_decision_from_venueid(submission),
             "openreview_id": submission.id,
         }
 

--- a/openreview/or2papers.py
+++ b/openreview/or2papers.py
@@ -128,12 +128,21 @@ def main(username, password, venue, download_all, download_pdfs):
             "presentation_type": presentation_type,
         }
         attachments = []
+
+        attachments_count = 0
+        suffix = ""
+
         for att_type in attachment_types:
             if att_type in submission.content and submission.content[att_type]:
+                if attachments_count == 0:
+                    suffix = ""
+                else:
+                    suffix = "_" + str(attachments_count)
+
                 attachments.append(
                     {
                         "type": attachment_types[att_type],
-                        "file": str(paper["id"])
+                        "file": str(paper["id"]) + suffix
                         + "."
                         + str(get_content_from(submission, att_type).split(".")[-1]),
                         "open_review_id": str(get_content_from(submission, att_type)),
@@ -144,11 +153,12 @@ def main(username, password, venue, download_all, download_pdfs):
                     f = client_acl_v2.get_attachment(submission.id, att_type)
                     with open(
                         os.path.join(
-                            attachments_folder, str(paper["id"]) + "." + file_tye
+                            attachments_folder, str(paper["id"]) + suffix + "." + file_tye
                         ),
                         "wb",
                     ) as op:
                         op.write(f)
+                attachments_count = attachments_count + 1
         if download_pdfs:
             f = client_acl_v2.get_pdf(id=paper["openreview_id"])
             with open(

--- a/openreview/or2papers.py
+++ b/openreview/or2papers.py
@@ -93,7 +93,7 @@ def main(username, password, venue, download_all, download_pdfs):
             abstract = ""
             if not abstract_flag:
                 abstract_flag = True
-                print("abstract field is not present. Contact info@openreview.net if you need this information migrated from ARR")
+                print(f"Paper {submission.id} abstract field is not present. Contact info@openreview.net if you need this information migrated from ARR")
 
         paper = {
             "id": submission.number,  # len(papers)+1,
@@ -112,7 +112,7 @@ def main(username, password, venue, download_all, download_pdfs):
         )
         if "track" not in submission.content and not track_flag:
             track_flag = True
-            print("track field is not present. Contact info@openreview.net if you need this information migrated from ARR")
+            print(f"Paper {submission.id} track field is not present. Contact info@openreview.net if you need this information migrated from ARR")
 
         if "paper_type" in submission.content:
             paper_type = " ".join(get_content_from(submission, "paper_type").split()[:2]).lower()
@@ -140,7 +140,7 @@ def main(username, password, venue, download_all, download_pdfs):
                     }
                 )
                 if download_all:
-                    file_tye = get_content_from(submission, "software").split(".")[-1]
+                    file_tye = get_content_from(submission, att_type).split(".")[-1]
                     f = client_acl_v2.get_attachment(submission.id, att_type)
                     with open(
                         os.path.join(

--- a/openreview/or2program_committee.py
+++ b/openreview/or2program_committee.py
@@ -42,9 +42,14 @@ def sort_user(t):
 
 def extract_or_data(client_acl, all_groups, role="Senior_Area_Chairs", or2acl={}):
     lst = []
-    for i, group in enumerate([g for g in all_groups if g.id.endswith(f"/{role}")]):
+    ## Groups will either look like venue_id/role or venue_id/track/role
+    for i, group in enumerate([g for g in all_groups if any(role == entry for entry in g.id.split('/'))]):
         # print(i, group.id)
-        or_track_name = group.id.split("/")[-1]
+        track = group.id.replace(acl_name, '').replace(role, '').strip('/')
+        if len(track) > 0:
+            or_track_name = f"{track}_{role}"
+        else:
+            or_track_name = role
         if or_track_name in or2acl:
             or_track_name = or2acl[or_track_name]
         t = { "role": or_track_name.replace("_"," "), "entries":[] }

--- a/openreview/or2program_committee.py
+++ b/openreview/or2program_committee.py
@@ -40,9 +40,9 @@ def sort_role(t):
 def sort_user(t):
     return t["last_name"]
 
-def extract_or_data(client_acl, regex="/.*/Senior_Area_Chairs", or2acl={}):
+def extract_or_data(client_acl, all_groups, role="Senior_Area_Chairs", or2acl={}):
     lst = []
-    for i, group in enumerate(openreview.tools.iterget_groups(client_acl, regex=acl_name+regex)):
+    for i, group in enumerate([g for g in all_groups if g.id.endswith(f"/{role}")]):
         # print(i, group.id)
         or_track_name = group.id.split("/")[-1]
         if or_track_name in or2acl:
@@ -93,7 +93,7 @@ else:
 # print(committees)
 
 # Fetch all groups and filter out the paper/submission groups
-all_groups = client_acl.get_all_groups(prefix = f"{acl_name}./*")
+all_groups = client_acl.get_all_groups(prefix = f"{acl_name}/.*")
 if not in_v2:
     all_groups = [g for g in all_groups if 'Paper' not in g.id]
 else:
@@ -102,17 +102,17 @@ else:
 program_committee = []
 
 # get PCs
-program_committee = extract_or_data(client_acl, regex="/Program_Chairs")
+program_committee = extract_or_data(client_acl, all_groups, role="Program_Chairs")
 
 # get SACs
 or2acl = {} # You can use this dictionary to replace OpenReview field names with others you want to use in the proceedings
-program_committee.extend(extract_or_data(client_acl, regex="/"+use_tracks+"Senior_Area_Chairs", or2acl=or2acl))
+program_committee.extend(extract_or_data(client_acl, all_groups, role="Senior_Area_Chairs", or2acl=or2acl))
 
 # get ACs
-program_committee.extend(extract_or_data(client_acl, regex="/"+use_tracks+"Area_Chairs", or2acl=or2acl))
+program_committee.extend(extract_or_data(client_acl, all_groups, role="Area_Chairs", or2acl=or2acl))
 
 # get reviewers
-aux = extract_or_data(client_acl, regex="/"+use_tracks+"Official_Review", or2acl=or2acl)
+aux = extract_or_data(client_acl, all_groups, role="Reviewers", or2acl=or2acl)
 for reviewer in aux:
     reviewer["type"]="name_block"
 program_committee.extend(aux)

--- a/openreview/or2program_committee.py
+++ b/openreview/or2program_committee.py
@@ -20,13 +20,20 @@ password = sys.argv[2]
 use_tracks = True
 
 try:
-    client_acl = openreview.Client(baseurl='https://api.openreview.net', username=username, password=password)
+    client_acl = openreview.api.OpenReviewClient(baseurl='https://api2.openreview.net', username=username, password=password)
 except:
     print("OpenReview connection refused")
     exit()
 
 acl_name = 'aclweb.org/ACL/2022/Conference' if len(sys.argv)<=3 else sys.argv[3]
 acl_name = acl_name.strip('/')
+
+try:
+    venue_group = client_acl.get_group(acl_name)
+    in_v2 = venue_group.domain is not None and venue_group.domain == venue_group.id
+except:
+    print(f"{acl_name} not found")
+    exit()
 
 def sort_role(t):
     return t["role"]
@@ -85,6 +92,12 @@ else:
 # committees = get_committee(acl_name)
 # print(committees)
 
+# Fetch all groups and filter out the paper/submission groups
+all_groups = client_acl.get_all_groups(prefix = f"{acl_name}./*")
+if not in_v2:
+    all_groups = [g for g in all_groups if 'Paper' not in g.id]
+else:
+    all_groups = [g for g in all_groups if 'Submission' not in g.id]
 
 program_committee = []
 

--- a/openreview/util.py
+++ b/openreview/util.py
@@ -88,3 +88,19 @@ def get_user(or_id,client_acl, force_institution=False):
         if 'semanticScholar' in c:
             ret["semantic_scholar_id"] = c['semanticScholar']
         return ret, False
+
+def get_content_from (submission, content_field):
+    # Given a paper from OpenReview (either openreview.Note or openreview.api.Note) and a field,
+    # get its value or None if value does not exist 
+    try:
+        if isinstance(submission, dict):
+            content = submission['content']
+        else:
+            content = submission.content
+    except:
+        raise Exception(f"submission must either be a dict, openreview.Note or openreview.api.Note, got type={type(submission)}")
+    ret = content.get(content_field)
+    if isinstance(ret, dict):
+        return ret['value']
+    else:
+        return ret

--- a/openreview/util.py
+++ b/openreview/util.py
@@ -110,3 +110,7 @@ def get_content_from (submission, content_field):
         return ret['value']
     else:
         return ret
+
+def get_decision_from_venueid (submission):
+    # Return the decision from venue id
+    return submission.content.get('venue', {}).get('value').split(' ')[-1]

--- a/openreview/util.py
+++ b/openreview/util.py
@@ -105,7 +105,7 @@ def get_content_from (submission, content_field):
             content = submission.content
     except:
         raise Exception(f"submission must either be a dict, openreview.Note or openreview.api.Note, got type={type(submission)}")
-    ret = content.get(content_field)
+    ret = content.get(content_field, '')
     if isinstance(ret, dict):
         return ret['value']
     else:

--- a/openreview/util.py
+++ b/openreview/util.py
@@ -42,12 +42,18 @@ def get_user(or_id,client_acl, force_institution=False):
         for name in c["names"]:
             if namePrefered==None or ('preferred' in name and name['preferred']):
                 namePrefered = name
-        name = " ".join([namePrefered['first'] if type(namePrefered['first'])==str else '', 
-                         namePrefered['middle'] if namePrefered['middle']!=None else '', 
-                         namePrefered['last'] if namePrefered['last']!=None else '' ]).replace("  ", " ")
-        first_name = namePrefered['first'].strip() if type(namePrefered['first'])==str else ''
-        middle_name = namePrefered['middle'].strip() if namePrefered['middle']!=None else ''
-        last_name = namePrefered['last'].strip() if namePrefered['last']!=None else ''
+        if "first" in namePrefered:
+            name = " ".join([namePrefered['first'] if type(namePrefered['first'])==str else '', 
+                            namePrefered['middle'] if namePrefered['middle']!=None else '', 
+                            namePrefered['last'] if namePrefered['last']!=None else '' ]).replace("  ", " ")
+            first_name = namePrefered['first'].strip() if type(namePrefered['first'])==str else ''
+            middle_name = namePrefered['middle'].strip() if namePrefered['middle']!=None else ''
+            last_name = namePrefered['last'].strip() if namePrefered['last']!=None else ''
+        else: ## first, middle, and last may not be present - OR switched to requiring only fullnames but this may change later for inclusivity
+            name = namePrefered['fullname']
+            first_name = namePrefered['fullname'].split(" ")[0]
+            last_name = namePrefered['fullname'].split(" ")[-1]
+            middle_name = " ".join(namePrefered['fullname'].split(" ")[1:-1])
         username = namePrefered['username'].strip()
         if len(first_name)>2:
             first_name = " ".join([n[0].upper() + n[1:].lower() if (n==n.upper() or n==n.lower()) else n for n in first_name.split(" ")])


### PR DESCRIPTION
This PR adds support for API2 by making the following changes to:

`or2papers.py`
- Initializes an API2 client
- Handles deprecation of query by notes with non-prefix invitation regex by fetching replies in details
- Adds separate logic for publication chairs vs program chairs
- Fetch content field depending on API version


`or2program_committee.py`
- Initializes an API2 client
- Handles deprecation of query by groups with non-prefix invitation regex by loading all conference groups and filtering as a post-process step