### PR TITLE
Fix Title Clashes and Enhance Customization for Invited Talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,16 @@ As with the prefaces, the contents of the `.tex` files should not include usual 
 and only what is usually found between the `\begin{document}` and `\end{document}` directives.
 
 ```yaml
-- speaker_name: Speaker name as it should appear, e.g. Jane Doe
-  institution: Speaker's institution name as it should appear, e.g. University of California Berkeley, USA
-  title: The title of the talk.
-  abstract_file: Path to abstract LaTeX file relative to the invited_talks/ directory.
-  bio_file: Path to bio LaTeX file relative to the invited_talks/ directory.
+- speaker_name: "Speaker name as it should appear, e.g., Jane Doe"
+  institution: "Speaker's institution name as it should appear, e.g., University of California Berkeley, USA"
+  title: "The title of the talk."
+  abstract_file: "Path to the abstract's LaTeX file relative to the invited_talks/ directory, e.g., invited_talks/jane_doe_abstract.tex"
+  bio_file: "Path to the bio's LaTeX file relative to the invited_talks/ directory e.g., invited_talks/jane_doe_bio.tex"
+  photo: "Path to the speaker's photo, relative to the invited_talks/ directory e.g., invited_talks/jane_doe_photo.jpg"
+  date: "Day of the invited talk, e.g., Mon, March 18, 2024"
+  time: "Time of the invited talk, e.g., 09:00 -- 10:00"
+  location: "Location of the invited talk, e.g., Room A"
+  custom_prefix: "Custom title for the page, e.g., Distinguished Lecture. This field allows customizing the default title of the page. If not provided, 'Keynote' is used."
 ```
 
 #### papers.yml

--- a/aclpub2/templates/proceedings.tex
+++ b/aclpub2/templates/proceedings.tex
@@ -236,7 +236,13 @@ ISBN \VAR{conference.isbn}
   \phantomsection
   \addcontentsline{toc}{section}{Keynote Talk: \VAR{talk.title}}
   \begin{center}
-    {\LARGE \textbf{Keynote Talk: \VAR{talk.title}}\\}
+    \BLOCK{if talk.custom_prefix}
+      {\Large \textbf{\VAR{talk.custom_prefix}}\\}
+      {\LARGE \textbf{\VAR{talk.title}}\\}
+    \BLOCK{else}
+      {\Large \textbf{Keynote Talk}\\}
+      {\LARGE \textbf{\VAR{talk.title}}\\}
+    \BLOCK{endif}
     \vspace*{0.5cm}
     %\begin{minipage}[c][0.35\linewidth][c]{0.35\linewidth}
      % \end{minipage}\\
@@ -285,7 +291,8 @@ ISBN \VAR{conference.isbn}
   \phantomsection
   \addcontentsline{toc}{section}{Panel: \VAR{panel.title}}
   \begin{center}
-    {\LARGE \textbf{Panel: \VAR{panel.title}}}
+    {\Large \textbf{Panel}\\}
+    {\LARGE \textbf{\VAR{panel.title}}\\}
     
     \BLOCK{if panel.photo}
         \begin{center}


### PR DESCRIPTION
- Changed the title format for keynotes and panels by replacing colons with newlines to avoid clashes with titles of panels and keynotes that contain colons.

- Added the ability to specify custom page titles for invited talks using strings different from 'keynote'.

- Updated the README file to reflect these changes.