### PR TITLE
Patch Issue #173

### DIFF
--- a/softconf/softconf2aclpub.py
+++ b/softconf/softconf2aclpub.py
@@ -262,16 +262,12 @@ def get_papers():
         for row in reader:
             authors = []
             if row["Acceptance Status"].startswith("Accept"):
-                author_cre = re.compile(r'(\d+): Last Name')
+                author_col = re.compile(r'(\d+): Last Name')
                 authors_i = sorted([
-                    int(author_cre.match(key).group(1))
-                    for key in row if author_cre.match(key)
+                    int(author_col.match(key).group(1))
+                    for key in row if author_col.match(key)
                 ])
                 for i in authors_i:
-                    try:
-                        row[f"{i}: Last Name"]
-                    except:
-                        continue
                     if row[f"{i}: Last Name"] != "":
                         authors.append({
                             "emails": row[f"{i}: Email"],

--- a/softconf/softconf2aclpub.py
+++ b/softconf/softconf2aclpub.py
@@ -262,7 +262,12 @@ def get_papers():
         for row in reader:
             authors = []
             if row["Acceptance Status"].startswith("Accept"):
-                for i in range(1, 11):
+                author_cre = re.compile(r'(\d+): Last Name')
+                authors_i = sorted([
+                    int(author_cre.match(key).group(1))
+                    for key in row if author_cre.match(key)
+                ])
+                for i in authors_i:
                     try:
                         row[f"{i}: Last Name"]
                     except:


### PR DESCRIPTION
I've revised #173 so that the list of authors is no longer truncated to the initial 10 authors. 

Instead of iterating over a fixed range of indices (from 1 to 10), now the code checks all possible row keys (columns) that match an indexed author's last name ("{i}: Last Name") and then extracts the indices and ensures they are sorted from first to last author.