### PR TITLE
Improve customization for non-ACL proceedings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ editors: list of the editors of the volume, in the form
 publisher: published of the conference, generally "Association for Computational Linguistics"
 volume_name: a tag used by the ACL Anthology to characterize the new volume in a group of proceedings. For a volume of the main conference, it should be a tag from the list long|short|srw|demo|findings. For other volumes, such as workshops, it should be set to 1
 watermark_book_title: [optional] If you do not want to use the text in the book_title as a watermark, you can specify here the alternative form. It is particularly usefull when the book_title is too long: in this case you can copy that text in this field and use the line break symbol \\ and, if the text is enclosed between " ", use \\\\
+proceedings_address: [optional] LaTeX table rows that replace the default address shown on the Copyright page of `proceedings.tex`, for ordering physical copies of proceedings. Each row should start with & (for the second column) and end with \\ (LaTeX line break). Use the | (pipe) character for multi-line literal strings in YAML. The lines should be indented consistently (the template will automatically remove the indentation). Example:
+  proceedings_address: |
+    & Association for Computational Linguistics (ACL)\\
+    & 317 Sidney Baker St. S \\
+    & Suite 400 - 134\\
+    & Kerrville, TX 78028\\
+    & USA\\
+    & Tel: +1-855-225-1962\\
+    &{\tt acl@aclweb.org}\\
 ```
 
 **Notice**: avoid using LaTeX escape codes but simply use the characters in UTF8, e.g., Rilić instead of Rili'\\{c})).

--- a/aclpub2/config.py
+++ b/aclpub2/config.py
@@ -17,8 +17,10 @@ def load_configs(root: Path):
     Loads all conference configuration files defined in the root directory.
     """
     conference = load_config("conference_details", root, required=True)
+    # Fields that contain raw LaTeX code and should not be escaped
+    raw_latex_fields = {'proceedings_address'}
     for item in conference:
-        if isinstance(conference[item], str):
+        if isinstance(conference[item], str) and item not in raw_latex_fields:
             conference[item] = normalize_latex_string(conference[item])
 
     papers = load_config("papers", root)

--- a/aclpub2/templates.py
+++ b/aclpub2/templates.py
@@ -92,6 +92,12 @@ def session_times(session) -> str:
     return f"{start} - {end}"
 
 
+def dedent_lines(text: str) -> str:
+    """Remove leading whitespace from each line while preserving the text."""
+    import textwrap
+    return textwrap.dedent(text)
+
+
 LATEX_JINJA_ENV = jinja2.Environment(
     block_start_string="\BLOCK{",
     block_end_string="}",
@@ -114,6 +120,7 @@ LATEX_JINJA_ENV.globals.update(
     index_author=index_author,
     index_speakers=index_speakers,
 )
+LATEX_JINJA_ENV.filters['dedent'] = dedent_lines
 
 
 def load_template(template: str) -> jinja2.Template:

--- a/aclpub2/templates/proceedings.tex
+++ b/aclpub2/templates/proceedings.tex
@@ -114,7 +114,6 @@
 \newpage
 \BLOCK{endif}
 
-
 %%%%%%%%%%%%%
 % Copyright %
 %%%%%%%%%%%%%
@@ -128,8 +127,14 @@
 
 \vspace*{2cm}
 \noindent
-Order copies of this and other ACL proceedings from:
+Order copies of this and other \VAR{conference.publisher} proceedings from:
 
+\BLOCK{if conference.proceedings_address is defined}
+\vspace*{1cm}
+\begin{tabular}{p{1.5cm}l}
+\VAR{conference.proceedings_address | dedent}
+\end{tabular}
+\BLOCK{else}
 \vspace*{1cm}
 \begin{tabular}{p{1.5cm}l}
 & Association for Computational Linguistics (ACL)\\
@@ -140,6 +145,7 @@ Order copies of this and other ACL proceedings from:
 & Tel: +1-855-225-1962\\
 &{\tt acl@aclweb.org}\\
 \end{tabular}
+\BLOCK{endif}
 
 \vspace*{1cm}
 ISBN \VAR{conference.isbn}
@@ -453,7 +459,7 @@ ISBN \VAR{conference.isbn}
     \put(0,13){\parbox[t]{\paperwidth}{\centering
     							\emph{\VAR{title}}, pages \VAR{paper.start_page}--\VAR{paper.end_page} \\
   	  						\VAR{conference_dates}, \VAR{conference.start_date.year} \textcopyright
-  							\VAR{conference.start_date.year} Association for Computational Linguistics}}
+                            \VAR{conference.start_date.year} \VAR{conference.publisher}}}
   }
   \includepdf[pagecommand={\thispagestyle{plain}},pages=-,addtotoc={1,section,1,{\VAR{paper.title}},ref:paper_{\VAR{paper.id}}}]{\VAR{root}/papers/\VAR{paper.file}}
 \BLOCK{endfor}

--- a/aclpub2/templates/watermarked_pdf.tex
+++ b/aclpub2/templates/watermarked_pdf.tex
@@ -44,7 +44,7 @@
   \put(0,13){\parbox[t]{\paperwidth}{\centering
   							\emph{\VAR{title}}, pages \VAR{paper.start_page}--\VAR{paper.end_page} \\
 	  						\VAR{conference_dates}, \VAR{conference.start_date.year} \textcopyright
-							\VAR{conference.start_date.year} Association for Computational Linguistics}}
+                            \VAR{conference.start_date.year} \VAR{conference.publisher}}}
 
 }
 \includepdf[pagecommand={\thispagestyle{plain}},pages=-]{\VAR{root}/papers/\VAR{paper.file}}


### PR DESCRIPTION
This PR adds improves the customization for non-ACL events. 


1. Use the actual publisher name from `conference_details.yaml` in the `proceedings.tex` and `watermarked_pdf.tex` templates instead of hardcoding ACL. 
2. Add a new YAML field called `proceedings_address` that will allow users to specify custom LaTeX table rows for the copyright/ordering address section in `proceedings.tex` instead of hardcoding ACL address. 
3. Add conditional block in `proceedings.tex` to use custom address when provided. If provided, apply a new `dedent` filter to handle YAML indentation gracefully. 
4. Update `config.py` to add `proceedings_address` to the list of raw LaTeX fields that should not be escaped.
5. Add detailed README documentation with examples showing proper YAML formatting for `proceedings_address` field. 