### PR TITLE
Remove \newline in panel code. Fixes #207

### DIFF
--- a/aclpub2/templates/proceedings.tex
+++ b/aclpub2/templates/proceedings.tex
@@ -314,7 +314,7 @@ ISBN \VAR{conference.isbn}
   \BLOCK{if panel.abstract_file}
   \VAR{load_file(root, "panels", panel.abstract_file)}\\
   \BLOCK{endif}
-  \newline
+
     %\begin{minipage}[c][0.35\linewidth][c]{0.35\linewidth}
      % \end{minipage}\\
     \BLOCK{if panel.moderators} 


### PR DESCRIPTION
Fixes a LaTeX syntax error in the panel generation.