### PR TITLE
Fix capitalize_name mangling hyphenated names into character-spaced strings

### DIFF
--- a/softconf/softconf2aclpub.py
+++ b/softconf/softconf2aclpub.py
@@ -46,7 +46,14 @@ def capitalize_name(name):
                         toks += [n]
                     else:
                         toks += [n[0].upper()+n[1:].lower()]
-        tokens_capitalized = "-".join(toks)
+        # Re-join the hyphenated first token into a single string, and keep it as
+        # one element of the token list together with the remaining tokens.  Note
+        # the list: assigning the joined string directly to ``tokens_capitalized``
+        # caused the final ``" ".join(...)`` to iterate over its characters,
+        # turning e.g. "Siang-Ting" into "S i a n g - T i n g".
+        tokens_capitalized = ["-".join(toks)] + [
+            token[0].upper()+token[1:].lower() for token in tokens[1:]
+        ]
     else:
         tokens_capitalized = [token[0].upper()+token[1:].lower() for token in tokens]
     return " ".join(tokens_capitalized)


### PR DESCRIPTION
## Bug

`capitalize_name()` in `softconf/softconf2aclpub.py` mangles any name whose first
space-separated token contains a hyphen, inserting a space between **every
character**:

```python
>>> capitalize_name("Siang-Ting")
'S i a n g - T i n g'
>>> capitalize_name("Amat-Lefort")
'A m a t - L e f o r t'
>>> capitalize_name("Coto-Solano")
'C o t o - S o l a n o'
```

### Root cause

In the hyphenated branch, `tokens_capitalized` is assigned a **string**
(`"-".join(toks)`), whereas the non-hyphenated branch assigns a **list**. The
function then ends with:

```python
return " ".join(tokens_capitalized)
```

`" ".join(<str>)` iterates over the string's **characters**, so `"Siang-Ting"`
becomes `"S i a n g - T i n g"`. Names without a hyphen are unaffected, which is
why only hyphenated (often romanized) names are corrupted.

A second latent bug: the hyphenated branch only processes `tokens[0]` and
silently **drops** `tokens[1:]`, so e.g. `"Anne-Marie Smith"` lost `"Smith"`
entirely.

### Impact

This corruption is written into `papers.yml` / `conference_details.yml` /
`program_committee.yml`. It surfaced in real ACL 2026 workshop proceedings
submitted for Anthology ingestion (dozens of authors across multiple workshops,
e.g. `Siang-Ting Lin`, `Natalia Amat-Lefort`), where it was caught in review:
acl-org/acl-anthology#8902.

## Fix

Keep `tokens_capitalized` a list in both branches, and include the remaining
tokens. Verified:

| input | before | after |
| --- | --- | --- |
| `Siang-Ting` | `S i a n g - T i n g` | `Siang-Ting` |
| `Amat-Lefort` | `A m a t - L e f o r t` | `Amat-Lefort` |
| `Anne-Marie Smith` | `A n n e - M a r i e` (Smith dropped) | `Anne-Marie Smith` |
| `Berlin` | `Berlin` | `Berlin` |
| `jean-luc picard` | `J e a n - L u c ...` | `Jean-Luc Picard` |

Non-hyphenated names are unchanged.
